### PR TITLE
docs: uso do MCP com Cursor/VSCode/Claude/Gemini-CLI/n8n

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,111 @@ uvicorn mcp_datajud.server:app --host 0.0.0.0 --port 8000
 ## Código
 
 Arquitetura em camadas: comunicação HTTP, parser, gerador dinâmico, interface MCP.
+
+## Arquitetura
+
+```mermaid
+graph LR
+  LLM["LLM / Smithery"] --> Srv["FastAPI Server\nGET /api/mcp/tool/list\nPOST /api/mcp/tool/call"]
+  CLI["CLI: mcp-datajud"] --> MCP["Camada 4: Interface MCP\nDataJudClient\nlist_tools() / execute_tool()"]
+  Srv --> MCP
+
+  subgraph "Cliente MCP (Python)"
+    MCP --> PARSER["Camada 2: Parser\nAPIParser\ncarrega spec (tribunais, paths, schema)"]
+    PARSER --> GEN["Camada 3: Gerador Dinâmico\nGera métodos por tribunal\nDocstrings & assinaturas"]
+    GEN --> DYN["Cliente Dinâmico\nCategorias por tribunal (ex.: tjsp, trt2)"]
+    DYN --> SESS["Camada 1: Comunicação\nDataJudSession\nAuth: APIKey {chave}\nRate Limiter + Retries\nLogs JSON"]
+  end
+
+  SESS --> DJ["API DataJUD (Elasticsearch)\n/api_publica_{tribunal}/_search (POST)"]
+
+  classDef box fill:#fff,stroke:#333,stroke-width:1px;
+  class LLM,Srv,CLI,MCP,PARSER,GEN,DYN,SESS,DJ box;
+```
+
+## Como usar o MCP com Cursor, VSCode, Claude, Gemini-CLI e n8n
+
+- Pré-requisitos
+  - Servidor rodando: `uvicorn mcp_datajud.server:app --host 0.0.0.0 --port 8000`
+  - Endpoints MCP (HTTP):
+    - `GET /api/mcp/tool/list` → `{ tools: [...] }`
+    - `POST /api/mcp/tool/call` → `{ result: ... }`
+
+- Smithery CLI (ponte HTTP → STDIO MCP)
+  - Execute como servidor MCP local (stdio):
+
+    ```bash
+    npx -y @smithery/cli mcp http --url http://127.0.0.1:8000
+    ```
+
+  - Opções úteis:
+    - `--list-endpoint /api/mcp/tool/list`
+    - `--call-endpoint /api/mcp/tool/call`
+
+- Cursor
+  - Tools → Add MCP Server → Nome: `mcp-datajud`
+  - Comando:
+
+    ```bash
+    npx -y @smithery/cli mcp http --url http://127.0.0.1:8000
+    ```
+
+  - O Cursor detectará e listará as ferramentas (ex.: `tjsp.buscar_processos`).
+
+- VSCode (Extensão Claude)
+  - Em `settings.json`:
+
+    ```json
+    {
+      "claude.mcpServers": {
+        "mcp-datajud": {
+          "command": "npx",
+          "args": ["-y", "@smithery/cli", "mcp", "http", "--url", "http://127.0.0.1:8000"]
+        }
+      }
+    }
+    ```
+
+- Claude Desktop (config MCP)
+  - Arquivo: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
+  - Adicione:
+
+    ```json
+    {
+      "mcpServers": {
+        "mcp-datajud": {
+          "command": "npx",
+          "args": ["-y", "@smithery/cli", "mcp", "http", "--url", "http://127.0.0.1:8000"]
+        }
+      }
+    }
+    ```
+
+- Gemini-CLI
+  - Use diretamente os endpoints HTTP em shell scripts:
+
+    ```bash
+    curl -s http://127.0.0.1:8000/api/mcp/tool/list | jq
+    curl -s -X POST http://127.0.0.1:8000/api/mcp/tool/call \
+      -H 'Content-Type: application/json' \
+      -d '{"toolName":"tjsp.buscar_processos","toolArgs":{"query":{"match_all":{}},"size":1}}' | jq
+    ```
+
+  - Alternativa: usar a ponte Smithery (comando acima) e integrar em workflows que aceitam processos MCP via STDIO.
+
+- n8n
+  - Node 1: HTTP Request (GET)
+    - URL: `http://127.0.0.1:8000/api/mcp/tool/list`
+    - Response: JSON → `{{$json["tools"]}}`
+  - Node 2: HTTP Request (POST)
+    - URL: `http://127.0.0.1:8000/api/mcp/tool/call`
+    - Body (JSON):
+
+      ```json
+      {
+        "toolName": "tjsp.buscar_processos",
+        "toolArgs": {"query": {"match_all": {}}, "size": 1}
+      }
+      ```
+
+  - Encadeie os nós para escolher a ferramenta e executar com parâmetros dinâmicos.


### PR DESCRIPTION
Este PR atualiza o README com instruções práticas para integrar o MCP DataJUD via Smithery e endpoints HTTP:\n\n- Cursor: configuração via ponte Smithery\n- VSCode (Claude): settings.json com mcpServers\n- Claude Desktop: claude_desktop_config.json\n- Gemini-CLI: exemplos HTTP (list/call)\n- n8n: fluxos com HTTP Request (GET list, POST call)\n\nInclui também diagrama Mermaid na seção Arquitetura.\n\nTestes locais:\n- uvicorn mcp_datajud.server:app --host 0.0.0.0 --port 8000\n- curl GET /api/mcp/tool/list | jq\n- curl POST /api/mcp/tool/call (tjsp.buscar_processos)\n\nObs: setar DATAJUD_API_KEY para execução real; listagem funciona sem a chave.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentação**
  * Adicionada uma explicação detalhada da arquitetura do sistema com diagrama ilustrativo.
  * Incluído guia de uso abrangente, com instruções para rodar o servidor e interagir via diferentes ferramentas e integrações.
  * Exemplos de comandos e configurações para facilitar a integração com diversas plataformas e automação de fluxos de trabalho.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->