### PR TITLE
docs: add docstrings to core request and tool functions

### DIFF
--- a/src/mcp_datajud/client.py
+++ b/src/mcp_datajud/client.py
@@ -43,6 +43,16 @@ class DataJudClient:
 
     # MCP: executa uma ferramenta
     def execute_tool(self, tool_name: str, **kwargs: Any) -> Dict[str, Any]:
+        """Executa uma ferramenta da API DataJUD gerada dinamicamente.
+
+        Args:
+            tool_name: Nome da ferramenta no formato ``categoria.metodo``.
+            **kwargs: Parâmetros a serem enviados à chamada da API.
+
+        Returns:
+            Um ``dict`` com a resposta da API ou um ``dict`` contendo a chave
+            ``error`` com a descrição do problema ocorrido.
+        """
         try:
             if "." not in tool_name:
                 return {"error": "Nome de ferramenta inválido. Use o formato categoria.metodo (ex.: tjsp.buscar_processos)."}

--- a/src/mcp_datajud/http_client.py
+++ b/src/mcp_datajud/http_client.py
@@ -46,6 +46,27 @@ class DataJudSession:
         params: Optional[Dict[str, Any]] = None,
         json_body: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
+        """Executa uma requisição HTTP à API DataJUD.
+
+        Respeita o rate limit configurado e realiza retentativas com backoff
+        exponencial para erros de rede e respostas 5xx.
+
+        Args:
+            method: Método HTTP ("GET", "POST", etc.).
+            path: Caminho relativo ao ``base_url``.
+            params: Parâmetros de querystring a serem enviados.
+            json_body: Corpo JSON da requisição.
+
+        Returns:
+            O corpo da resposta já convertido para ``dict`` quando possível ou
+            um ``dict`` contendo o texto bruto em ``{"raw": resp.text}``.
+
+        Raises:
+            APIRateLimitError: Quando o limite de requisições é excedido.
+            AuthenticationError: Para respostas 401 ou 403.
+            NotFoundError: Para respostas 404.
+            APIError: Para outros erros da API ou de rede.
+        """
         url = f"{self.base_url}{path}"
         attempt = 0
         last_exc: Optional[Exception] = None


### PR DESCRIPTION
## Summary
- document the HTTP client's `request` method to clarify retry, rate limit and errors
- add docstring to dynamic `execute_tool` helper for better API guidance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896bd04f1f4832a8d0747fe1ae71d39